### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,8 @@ jobs:
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/FlightSchool-io/starter-workflows/security/code-scanning/3](https://github.com/FlightSchool-io/starter-workflows/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the job level (specific to the `pre-commit` job). Since the workflow only performs linting and does not require write access, we will set `contents: read` as the minimal permission. This ensures that the workflow has only the permissions it needs to function correctly.

The changes will be made in the `.github/workflows/lint.yaml` file, specifically by adding the `permissions` block under the `pre-commit` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
